### PR TITLE
[Proposal] Change debug level to CreateNewBlock()

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -234,7 +234,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         pblocktemplate->vTxFees[0] = -nFees;
     }
 
-    LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    // Change debug level BEGIN
+    // LogPrintf("CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    LogPrint(BCLog::ALL, "CreateNewBlock(): block weight: %u txs: %u fees: %ld sigops %d\n", GetBlockWeight(*pblock), nBlockTx, nFees, nBlockSigOpsCost);
+    // Change debug level END
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();


### PR DESCRIPTION
A proposal for issue #29, regarding the multiple record of _"CreateNewBlock(): block weig...."_ in the log.

The log level was changed, compiled and tested on OS Linux (Ubuntu 18.04 LTS) for 24 hours with no problems, on the testnet, mining blocks in both the SHA algorithm and MinX.