### PR TITLE
Fix for gcc 12.2.0 Linux devuan 6.1.0-16-amd64: some includes, fix al…

### DIFF
--- a/src/crypto/minotaurx/blake2.h
+++ b/src/crypto/minotaurx/blake2.h
@@ -61,7 +61,8 @@ extern "C" {
     uint8_t  personal[BLAKE2S_PERSONALBYTES];  // 32
   } blake2s_param;
 
-  ALIGN( 64 ) typedef struct __blake2s_state
+  //ALIGN( 64 ) typedef struct __blake2s_state
+  typedef struct ALIGN( 64 ) __blake2s_state
   {
     uint32_t h[8];
     uint32_t t[2];
@@ -86,7 +87,8 @@ extern "C" {
     uint8_t  personal[BLAKE2B_PERSONALBYTES];  // 64
   } blake2b_param;
 
-  ALIGN( 64 ) typedef struct __blake2b_state
+  //ALIGN( 64 ) typedef struct __blake2b_state
+  typedef struct ALIGN( 64 ) __blake2b_state
   {
     uint64_t h[8];
     uint64_t t[2];

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -37,6 +37,8 @@
 #endif
 #endif
 
+#include <deque>
+
 /** Maximum size of http request (request line + headers) */
 static const size_t MAX_HEADERS_SIZE = 8192;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -561,12 +561,16 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
-#if QT_VERSION >= 0x050600
+#if QT_VERSION > QT_VERSION_CHECK(5, 12, 0)
+#elif QT_VERSION >= 0x050600
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 #ifdef Q_OS_MAC

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -60,6 +60,10 @@
 #include <QUrlQuery>
 #endif
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MAC)
         "macosx"

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -25,6 +25,10 @@
 #include <QDebug>
 #include <QTimer>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;

--- a/src/qt/qcustomplot.h
+++ b/src/qt/qcustomplot.h
@@ -93,6 +93,8 @@
 //#  include <QtPrintSupport/QtPrintSupport>
 #endif
 
+#include <QPainterPath>
+
 class QCPPainter;
 class QCustomPlot;
 class QCPLayerable;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -26,6 +26,10 @@
 #include <QPainter>
 #include <QRadialGradient>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/tinypie.h
+++ b/src/qt/tinypie.h
@@ -7,6 +7,8 @@
 #include <QPainter>
 #include <QPaintEvent>
 
+#include <QPainterPath>
+
 class TinyPie : public QWidget
 {
 public:

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -8,6 +8,8 @@
 #include <QWidget>
 #include <QQueue>
 
+#include <QPainterPath>
+
 class ClientModel;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -26,6 +26,10 @@
 #include <QIcon>
 #include <QList>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -39,6 +39,10 @@
 
 #include <policy/policy.h>  // LitecoinCash: Hive: For GetVirtualTransactionSize
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),
     transactionTableModel(0),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,6 +54,10 @@
 # error "LitecoinCash cannot be compiled without assertions."
 #endif
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 #define MICRO 0.000001
 #define MILLI 0.001
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -19,6 +19,10 @@
 
 #include <boost/signals2/signal.hpp>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;


### PR DESCRIPTION
Hello. I got many errors while building on Linux Devuan:

```
gcc version 12.2.0 (Debian 12.2.0-14) 
~$ uname -a
Linux devuan 6.1.0-16-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.67-1 (2023-12-12) x86_64 GNU/Linux
~$ apt list --installed 2>/dev/null | grep qtbase5-dev
qtbase5-dev-tools/stable,now 5.15.8+dfsg-11 amd64 [installed,automatic]
qtbase5-dev/stable,now 5.15.8+dfsg-11 amd64 [installed,automatic]
~$ apt list --installed 2>/dev/null | grep build-ess
build-essential/stable,now 12.9 amd64 [installed]
```

Here it is a process of fixing. Here `v` is alias of `vim`

```
##2024-01-02 07:50 install litecoincash 0.16.3 litecoinca.sh
wget https://github.com/litecoincash-project/litecoincash/archive/refs/tags/v0.16.3.tar.gz
tar -xf v0.16.3.tar.gz
cd litecoincash-0.16.3/
./autogen.sh
./configure --with-incompatible-bdb
make
  httpserver.cpp:32:1: note: ‘std::deque’ is defined in header ‘<deque>’; did you forget to ‘#include <deque>’?
     31 | #include <support/events.h>
    +++ |+#include <deque>
v src/httpserver.cpp
  40:#include <deque>
make
  validation.cpp: In constructor ‘ConnectTrace::ConnectTrace(CTxMemPool&)’:
  validation.cpp:2354:94: error: ‘_1’ was not declared in this scope
   2354 |         pool.NotifyEntryRemoved.connect(boost::bind(&ConnectTrace::NotifyEntryRemoved, this, _1, _2));
v src/validation.cpp
  57:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
  validationinterface.cpp:65:91: error: ‘_1’ was not declared in this scope
     65 |     pool.NotifyEntryRemoved.connect(boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
v src/validationinterface.cpp
  22:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  In file included from crypto/minotaurx/blake2s-ref.c:18:
  crypto/minotaurx/blake2.h:101:5: error: size of array element is not a multiple of its alignment
    101 |     blake2s_state S[8][1];
  ##not helped: https://github.com/Raptor3um/raptoreum/issues/48#issuecomment-969125200
  ##https://github.com/litecoincash-project/cpuminer-multi/issues/7
v src/crypto/minotaurx/blake2.h
  64://ALIGN( 64 ) typedef struct __blake2s_state
  typedef struct ALIGN( 64 ) __blake2s_state
  90://ALIGN( 64 ) typedef struct __blake2b_state
  typedef struct ALIGN( 64 ) __blake2b_state
make
    CXX      qt/libbitcoinqt_a-qcustomplot.o
  In file included from qt/qcustomplot.cpp:26:
  qt/qcustomplot.h:2389:16: error: field ‘mCustomPath’ has incomplete type ‘QPainterPath’
   2389 |   QPainterPath mCustomPath;
  ..
  qt/qcustomplot.cpp: In member function ‘void QCPScatterStyle::setFromOther(const QCPScatterStyle&, ScatterProperties)’:
  qt/qcustomplot.cpp:10049:37: error: invalid use of void expression
  10049 |       setCustomPath(other.customPath());
  ...
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qflags.h:123:80: note: declared here
    123 |     QT_DEPRECATED_X("Use default constructor instead") Q_DECL_CONSTEXPR inline QFlags(Zero) noexcept : i(0) {}
        |                                                                                ^~~~~~
  qt/qcustomplot.cpp: In member function ‘virtual double QCPItemCurve::selectTest(const QPointF&, bool, QVariant*) const’:
  qt/qcustomplot.cpp:28582:34: error: variable ‘QPainterPath cubicPath’ has initializer but incomplete type
  28582 |   QPainterPath cubicPath(startVec);
        |                                  ^
  qt/qcustomplot.cpp: In member function ‘virtual void QCPItemCurve::draw(QCPPainter*)’:
  qt/qcustomplot.cpp:28610:26: error: variable ‘QPainterPath cubicPath’ has initializer but incomplete type
  28610 |   QPainterPath cubicPath(startVec.toPointF());
        |                          ^~~~~~~~
  qt/qcustomplot.cpp: In member function ‘virtual void QCPItemBracket::draw(QCPPainter*)’:
  qt/qcustomplot.cpp:30145:22: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  30145 |         QPainterPath path;
  ##https://forum.qt.io/topic/122702/error-aggregate-qpainterpath-path-has-incomplete-type-and-cannot-be-defined
  ##include <QPainterPath> may be missing. Just add it.
v src/qt/qcustomplot.h
  96:#include <QPainterPath>
make
    CXX      qt/libbitcoinqt_a-tinypie.o
  qt/tinypie.cpp: In member function ‘virtual void TinyPie::paintEvent(QPaintEvent*)’:
  qt/tinypie.cpp:37:18: error: variable ‘QPainterPath path’ has initializer but incomplete type
     37 |     QPainterPath path = HexPath(0.011, width()/2, height()/2);
        |                  ^~~~
  qt/tinypie.cpp:37:32: error: invalid use of incomplete type ‘class QPainterPath’
     37 |     QPainterPath path = HexPath(0.011, width()/2, height()/2);
        |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /usr/include/x86_64-linux-gnu/qt5/QtGui/qbrush.h:49,
                   from /usr/include/x86_64-linux-gnu/qt5/QtGui/qpalette.h:46,
                   from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:48,
                   from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QWidget:1,
                   from ./qt/tinypie.h:6,
                   from qt/tinypie.cpp:3:
  /usr/include/x86_64-linux-gnu/qt5/QtGui/qmatrix.h:54:7: note: forward declaration of ‘class QPainterPath’
     54 | class QPainterPath;
        |       ^~~~~~~~~~~~
  qt/tinypie.cpp:41:19: error: invalid use of incomplete type ‘class QPainterPath’
     41 |     path = HexPath(0.009, width()/2, height()/2);
        |            ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /usr/include/x86_64-linux-gnu/qt5/QtGui/qmatrix.h:54:7: note: forward declaration of ‘class QPainterPath’
     54 | class QPainterPath;
        |       ^~~~~~~~~~~~
  qt/tinypie.cpp: At global scope:
  qt/tinypie.cpp:48:75: error: return type ‘class QPainterPath’ is incomplete
     48 | QPainterPath TinyPie::HexPath(double scale, double centerX, double centerY) {
        |                                                                           ^
  qt/tinypie.cpp: In member function ‘void TinyPie::HexPath(double, double, double)’:
  qt/tinypie.cpp:52:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
     52 |     QPainterPath path;
v src/qt/tinypie.h
  10:#include <QPainterPath>
make
  qt/bitcoingui.cpp: In member function ‘void BitcoinGUI::subscribeToCoreSignals()’:
  qt/bitcoingui.cpp:1226:86: error: ‘_1’ was not declared in this scope
   1226 |     uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, this, _1, _2, _3));
v src/qt/bitcoingui.cpp
  63:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
    CXX      qt/libbitcoinqt_a-clientmodel.o
  qt/clientmodel.cpp: In member function ‘void ClientModel::subscribeToCoreSignals()’:
  qt/clientmodel.cpp:319:70: error: ‘_1’ was not declared in this scope
    319 |     uiInterface.ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
v src/qt/clientmodel.cpp
  28:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
  qt/splashscreen.cpp: In member function ‘void SplashScreen::ConnectWallet(CWallet*)’:
  qt/splashscreen.cpp:185:66: error: ‘_1’ was not declared in this scope
    185 |     wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2, false));
v src/qt/splashscreen.cpp
  29:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
    CXX      qt/libbitcoinqt_a-trafficgraphwidget.o
  qt/trafficgraphwidget.cpp: In member function ‘void TrafficGraphWidget::paintPath(QPainterPath&, QQueue<float>&)’:
  qt/trafficgraphwidget.cpp:54:9: error: invalid use of incomplete type ‘class QPainterPath’
     54 |         path.moveTo(x, YMARGIN + h);
v src/qt/trafficgraphwidget.h
  11:#include <QPainterPath>
make
  qt/transactiontablemodel.cpp: In member function ‘void TransactionTableModel::subscribeToCoreSignals()’:
  qt/transactiontablemodel.cpp:809:90: error: ‘_1’ was not declared in this scope
    809 |     wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
v src/qt/transactiontablemodel.cpp
  29:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
  qt/walletmodel.cpp:523:89: error: ‘_1’ was not declared in this scope
    523 |     wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
v src/qt/walletmodel.cpp
  42:#include <boost/bind/bind.hpp>
    #include <boost/signals2/signal.hpp>
    using namespace boost::placeholders;
make
./src/qt/litecoincash-qt
  ##works finally
```